### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,6 @@
 name: "Validate devcontainer-feature.json files"
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/stargrid-systems/devcontainer-features/security/code-scanning/9](https://github.com/stargrid-systems/devcontainer-features/security/code-scanning/9)

In general, to fix this class of issues you add an explicit `permissions:` block either at the top level of the workflow (applies to all jobs) or under each job (applies per job). The block should grant only the scopes and access levels actually required by the job. For a validation workflow that just checks out the repository and runs a validation action, `contents: read` is typically sufficient.

For this specific workflow in `.github/workflows/validate.yml`, the simplest least-privilege fix without changing functionality is to add a `permissions:` block at the workflow (root) level, just below the `name:` line and before `on:`. This will apply to the `validate` job since it has no job-specific `permissions:` block. Set `contents: read` to allow checkout and any read-only operations on the repository while preventing writes. No imports, methods, or additional definitions are needed because this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
